### PR TITLE
fix: support iOS dark mode with palette colors

### DIFF
--- a/AddLocationDialog.qml
+++ b/AddLocationDialog.qml
@@ -44,6 +44,7 @@ Dialog {
             Label {
                 text: "Location Name"
                 font.bold: true
+                color: palette.windowText
                 Layout.fillWidth: true
             }
             
@@ -60,6 +61,7 @@ Dialog {
             Label {
                 text: "Latitude"
                 font.bold: true
+                color: palette.windowText
                 Layout.fillWidth: true
             }
             
@@ -81,6 +83,7 @@ Dialog {
             Label {
                 text: "Longitude"
                 font.bold: true
+                color: palette.windowText
                 Layout.fillWidth: true
             }
             

--- a/Header.qml
+++ b/Header.qml
@@ -8,12 +8,12 @@ Rectangle {
     anchors.right: parent.right
     anchors.left: parent.left
     height: 80
-    color: "white"
+    color: palette.window
     opacity: 0.8
 
     Label {
         text: header.text
-        color: "black"
+        color: palette.windowText
         font.pixelSize: 16 * Screen.devicePixelRatio
         font.bold: true
         anchors.verticalCenter: parent.verticalCenter

--- a/InfoBox.qml
+++ b/InfoBox.qml
@@ -17,7 +17,7 @@ Rectangle {
     anchors.bottom: parent.bottom
     anchors.left: parent.left
     anchors.right: parent.right
-    color: Qt.rgba(1.0, 1.0, 1.0, 0.7)
+    color: Qt.rgba(palette.window.r, palette.window.g, palette.window.b, 0.7)
     visible: false
 
     Column {
@@ -26,36 +26,44 @@ Rectangle {
         Row {
             Text {
                 text: "Name: "
+                color: palette.windowText
             }
             Text {
                 text: root.lighthouse ? root.lighthouse.name : ""
+                color: palette.windowText
             }
         }
 
         Row {
             Text {
                 text: "Distance: "
+                color: palette.windowText
             }
             Text {
                 text: root.lighthouse ? root.lighthouse.distance.toFixed(0.0) + ' m' : ""
+                color: palette.windowText
             }
         }
 
         Row {
             Text {
                 text: "Height: "
+                color: palette.windowText
             }
             Text {
                 text: root.lighthouse ? root.lighthouse.heightOverSea + ' m' : ""
+                color: palette.windowText
             }
         }
 
         Row {
             Text {
                 text: "Heading: "
+                color: palette.windowText
             }
             Text {
                 text: Math.round(root.heading / Math.PI * 180, 0)
+                color: palette.windowText
             }
         }
     }

--- a/SettingsView.qml
+++ b/SettingsView.qml
@@ -229,8 +229,15 @@ Page {
                         onClicked: listView.currentIndex = index
                         swipe.enabled: index > 0 // Disable swiping for "Use current location" (index 0)
 
+                        contentItem: Text {
+                            text: swipeDelegate.text
+                            color: listView.currentIndex === index ? palette.highlightedText : palette.text
+                            verticalAlignment: Text.AlignVCenter
+                            leftPadding: 16
+                        }
+
                         background: Rectangle {
-                            color: listView.currentIndex === index ? "#e0e0e0" : "white"
+                            color: listView.currentIndex === index ? palette.highlight : palette.base
                         }
 
                         ListView.onRemove: removeAnimation.start()

--- a/SvgButton.qml
+++ b/SvgButton.qml
@@ -8,7 +8,7 @@ Rectangle {
     height: 44
     radius: 5
     color: Qt.rgba(1.0, 1.0, 1.0, 0.0)
-    border.color: "#000"
+    border.color: palette.buttonText
     border.width: 2
     property var fileName
     property real imageScale: 1

--- a/main.qml
+++ b/main.qml
@@ -74,7 +74,7 @@ Window {
         width: 44
         height: 44
         color: Qt.rgba(1.0, 1.0, 1.0, 0.0)
-        border.color: "#000"
+        border.color: palette.buttonText
         border.width: stack.currentItem === map ? 2 : 0
         radius: 5
     }


### PR DESCRIPTION
## Problem
When iOS dark mode is enabled, the app shows white text on white backgrounds and has other visibility issues, especially in the Settings view.

## Changes
Replaced hardcoded colors with Qt's palette system to properly support both light and dark modes:

- **SettingsView.qml**: Location list now uses `palette.base`, `palette.highlight`, `palette.text`, and `palette.highlightedText` for proper contrast
- **Header.qml**: Background and text use `palette.window` and `palette.windowText`
- **SvgButton.qml**: Border uses `palette.buttonText`
- **AddLocationDialog.qml**: Labels use `palette.windowText`
- **InfoBox.qml**: Background and text adapt to system appearance
- **main.qml**: Settings button border uses `palette.buttonText`

## Testing
The palette system automatically adapts to iOS appearance mode, ensuring proper contrast in both light and dark modes.

Fixes white text on white background issue reported in the Settings view.