### PR TITLE
fix: configure OSM plugin to use free tile server without API key

### DIFF
--- a/MapLocationSelector.qml
+++ b/MapLocationSelector.qml
@@ -17,12 +17,25 @@ import QtQuick.Shapes 1.15
     Plugin {
         id: mapPlugin
         name: "osm"
+        PluginParameter {
+            name: "osm.mapping.providersrepository.disabled"
+            value: true
+        }
+        PluginParameter {
+            name: "osm.mapping.custom.host"
+            value: "https://tile.openstreetmap.org/%z/%x/%y.png"
+        }
+        PluginParameter {
+            name: "osm.mapping.copyright"
+            value: "© OpenStreetMap contributors"
+        }
     }
 
     Map {
         id: map
         anchors.fill: parent
         plugin: mapPlugin
+        activeMapType: supportedMapTypes[supportedMapTypes.length - 1]
         zoomLevel: 10
         copyrightsVisible: true
 

--- a/MapMode.qml
+++ b/MapMode.qml
@@ -51,12 +51,25 @@ Item {
     Plugin {
         id: mapPlugin
         name: "osm"
+        PluginParameter {
+            name: "osm.mapping.providersrepository.disabled"
+            value: true
+        }
+        PluginParameter {
+            name: "osm.mapping.custom.host"
+            value: "https://tile.openstreetmap.org/%z/%x/%y.png"
+        }
+        PluginParameter {
+            name: "osm.mapping.copyright"
+            value: "© OpenStreetMap contributors"
+        }
     }
 
     Map {
         id: map
         anchors.fill: parent
         plugin: mapPlugin
+        activeMapType: supportedMapTypes[supportedMapTypes.length - 1]
         zoomLevel: 14
         bearing: compassBearing
         copyrightsVisible: false


### PR DESCRIPTION
Fixes the 'API key required' watermark that was appearing on map tiles at certain zoom levels.

## Changes
- Configure OSM plugin to disable default providers repository
- Set custom tile server host to OpenStreetMap's free service
- Add explicit tile URL template with zoom/coordinate placeholders
- Force activeMapType to use the custom configuration

## Testing
Verified that maps now load correctly at all zoom levels without API key requirement watermark.