### PR TITLE
fix: filter out lighthouses with zero sectors during parsing

### DIFF
--- a/scripts/parse.py
+++ b/scripts/parse.py
@@ -152,6 +152,8 @@ def parse_lighthouses(text_elements, page_number):
             return False
         if lighthouse.height is None:
             return False
+        if len(lighthouse.sectors) == 0:
+            return False
         return True
 
     lighthouses_on_page = {


### PR DESCRIPTION
This PR adds a filter to exclude lighthouses that have zero sectors during the parsing process. Lighthouses without sector information will now be filtered out before being written to lighthouses.json and LighthouseList.qml.